### PR TITLE
Correccion de la ruta de subida de videos

### DIFF
--- a/src/main/java/com/api/streaming/controller/VideoController.java
+++ b/src/main/java/com/api/streaming/controller/VideoController.java
@@ -21,7 +21,7 @@ public class VideoController{
     @Autowired
     private VideoService videoService;
 
-    @PostMapping(value = "/videoupload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Video> videoUpload(@ModelAttribute @Valid VideoUploadRequest request){
         return ResponseEntity.status(HttpStatus.CREATED).body(videoService.storeVideo(request));
     }


### PR DESCRIPTION
la ruta api/videos/upload no tenia el estandard correcto, se cambio para que la ruta api/videos con el metodo POST fuera el de subida del video